### PR TITLE
fix error when playlist contains premiere or live

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,9 @@ function getDuration() {
     for (var i = 0; i < timeStamp.length; i++) {
         var timeString = timeStamp[i].innerHTML;
         var HMS = timeString.split(':');
+        if (HMS.length) === 1)
+            continue;
+        
         if(HMS.length === 3) {
             hours   = parseInt(HMS[0]);
             minutes = parseInt(HMS[1]);


### PR DESCRIPTION
fix #4 

When playlist contains something that is not time, in `timeString` (for example live or premiere message), it shows `NaN:NaN`, I think that would fix it 

![image](https://user-images.githubusercontent.com/19672992/107105881-01518680-6829-11eb-8867-a4194e7bae52.png)
![image](https://user-images.githubusercontent.com/19672992/107105885-07476780-6829-11eb-8f40-67913fa99548.png)
